### PR TITLE
Allow output path of only filename (current directory without ".\")

### DIFF
--- a/src/PWEncryptionTool/Program.cs
+++ b/src/PWEncryptionTool/Program.cs
@@ -74,7 +74,12 @@ namespace PWEncryptionTool
             else
             {
                 byte[] processedData = ProcessData(data, encrypt);
-                Directory.CreateDirectory(Path.GetDirectoryName(opts.OutputFile));
+                string outputDir = Path.GetDirectoryName(opts.OutputFile);
+                if (!string.IsNullOrEmpty(outputDir))
+                {
+                    Directory.CreateDirectory(outputDir);
+                }
+
                 File.WriteAllBytes(opts.OutputFile, processedData);
                 Console.WriteLine(" DONE!");
             }


### PR DESCRIPTION
Prevents System.ArgumentException when specifying an output path
without a leading directory due to a missing null/empty check.

This caused one to have to write:
[command] inputfile.unity3d .\outputfile.unity3d

instead of simply:
[command] inputfile.unity3d outputfile.unity3d

when the desired output location was the current directory.